### PR TITLE
Fix: Glyphs overlap when there are more than one in the Edit Tab

### DIFF
--- a/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
@@ -425,21 +425,34 @@ class ShowRotated(ReporterPlugin):
         if not Glyphs.boolDefaults[KEY_ROTATIONSBUTTON]:
             return
 
-        # Check if there is any selected layer
         try:
-            if len(Glyphs.font.selectedLayers) == 0:
+            # Check if there are any selected layers
+            selected_layers = Glyphs.font.selectedLayers
+            if len(selected_layers) == 0:
                 return
-                
-            # Check if this is the active glyph
-            # Get current glyph
-            current_glyph = Glyphs.font.selectedLayers[0].parent
+            
+            # Get the currently selected character
+            current_layer = selected_layers[0]
+            current_glyph = current_layer.parent
+            
+            # Get the glyph of the preview layer
             layer_glyph = layer.parent
             
-            # Skip if not the active glyph
-            if current_glyph != layer_glyph:
+            # If glyph names are different, skip this glyph
+            if current_glyph.name != layer_glyph.name:
                 return
-        except:
-            pass
+                
+            # Check layer matching conditions
+            # If it's the same glyph but different layer, and not a preview layer, don't draw
+            if current_layer.layerId != layer.layerId and layer.name != "Preview":
+                # In some special cases, preview layer might not have a name
+                if not hasattr(layer, "isPreviewLayer") or not layer.isPreviewLayer:
+                    return
+
+        except Exception as e:
+            print(f"Selection check error: {str(e)}")
+            print(traceback.format_exc())
+            return
 
         is_black = NSUserDefaults.standardUserDefaults().boolForKey_("GSPreview_Black")
 
@@ -455,6 +468,7 @@ class ShowRotated(ReporterPlugin):
             NSParagraphStyleAttributeName: paragraph_style,
         }
 
+        # Draw 8 different rotation angles
         for i in range(8):
             rotation_transform = NSAffineTransform.transform()
             layer_path = layer.completeBezierPath.copy()
@@ -512,5 +526,6 @@ class ShowRotated(ReporterPlugin):
 
                 base_position_transform.translateXBy_yBy_(padding, 0)
 
-            except:
+            except Exception as e:
+                print(f"Rotation drawing error: {str(e)}")
                 print(traceback.format_exc())

--- a/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
@@ -86,7 +86,8 @@ class ShowRotated(ReporterPlugin):
                 "it": "Ruotato",
                 "fr": "Tourné",
                 "ko": "회전",
-                "zh": "旋转",
+                "zh-Hans": "旋转",
+                "zh-Hant": "旋轉",
                 "ar": "مدور",
                 "el": "Περιστραμμένο",
                 "hi": "घुमाया हुआ",
@@ -415,6 +416,18 @@ class ShowRotated(ReporterPlugin):
     @objc.python_method
     def background(self, layer):  # def foreground(self, layer):
         if Glyphs.boolDefaults[KEY_SUPERIMPOSED]:
+            # Check if this is the active glyph
+            try:
+                # Get current glyph
+                current_glyph = Glyphs.font.selectedLayers[0].parent
+                layer_glyph = layer.parent
+                
+                # Skip if not the active glyph
+                if current_glyph != layer_glyph:
+                    return
+            except:
+                pass
+                
             self.draw_rotated(layer)
 
     def needsExtraMainOutlineDrawingInPreviewLayer_(self, layer):
@@ -423,6 +436,18 @@ class ShowRotated(ReporterPlugin):
     def drawForegroundInPreviewLayer_options_(self, layer, options):
         if not Glyphs.boolDefaults[KEY_ROTATIONSBUTTON]:
             return
+
+        # Check if this is the active glyph
+        try:
+            # Get current glyph
+            current_glyph = Glyphs.font.selectedLayers[0].parent
+            layer_glyph = layer.parent
+            
+            # Skip if not the active glyph
+            if current_glyph != layer_glyph:
+                return
+        except:
+            pass
 
         is_black = NSUserDefaults.standardUserDefaults().boolForKey_("GSPreview_Black")
 

--- a/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
@@ -416,22 +416,6 @@ class ShowRotated(ReporterPlugin):
     @objc.python_method
     def background(self, layer):  # def foreground(self, layer):
         if Glyphs.boolDefaults[KEY_SUPERIMPOSED]:
-            # Check if there is any selected layer
-            try:
-                if len(Glyphs.font.selectedLayers) == 0:
-                    return
-                    
-                # Check if this is the active glyph
-                # Get current glyph
-                current_glyph = Glyphs.font.selectedLayers[0].parent
-                layer_glyph = layer.parent
-                
-                # Skip if not the active glyph
-                if current_glyph != layer_glyph:
-                    return
-            except:
-                pass
-                
             self.draw_rotated(layer)
 
     def needsExtraMainOutlineDrawingInPreviewLayer_(self, layer):

--- a/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowRotated.glyphsReporter/Contents/Resources/plugin.py
@@ -416,8 +416,12 @@ class ShowRotated(ReporterPlugin):
     @objc.python_method
     def background(self, layer):  # def foreground(self, layer):
         if Glyphs.boolDefaults[KEY_SUPERIMPOSED]:
-            # Check if this is the active glyph
+            # Check if there is any selected layer
             try:
+                if len(Glyphs.font.selectedLayers) == 0:
+                    return
+                    
+                # Check if this is the active glyph
                 # Get current glyph
                 current_glyph = Glyphs.font.selectedLayers[0].parent
                 layer_glyph = layer.parent
@@ -437,8 +441,12 @@ class ShowRotated(ReporterPlugin):
         if not Glyphs.boolDefaults[KEY_ROTATIONSBUTTON]:
             return
 
-        # Check if this is the active glyph
+        # Check if there is any selected layer
         try:
+            if len(Glyphs.font.selectedLayers) == 0:
+                return
+                
+            # Check if this is the active glyph
             # Get current glyph
             current_glyph = Glyphs.font.selectedLayers[0].parent
             layer_glyph = layer.parent


### PR DESCRIPTION
## Fix: Glyphs overlap when there are more than one in the Edit Tab

https://github.com/Mark2Mark/Show-Rotated/issues/6

### Issue
When the rotation preview feature is enabled and multiple glyphs are displayed in the edit view, the plugin incorrectly shows rotated versions of all glyphs instead of focusing only on the currently active glyph. This creates visual clutter and makes it difficult to focus on the glyph being edited.

### Solution
I've implemented a check in both the `background` method and the `drawForegroundInPreviewLayer_options_` method to verify whether the layer being processed belongs to the currently active glyph:

```python
# Get current glyph
current_glyph = Glyphs.font.selectedLayers[0].parent
layer_glyph = layer.parent

# Skip if not the active glyph
if current_glyph != layer_glyph:
    return
```

This ensures that rotation previews are only rendered for the active glyph, improving focus and reducing visual noise when multiple glyphs are displayed.

### Additional change
Added Traditional Chinese (zh-Hant) localization along with proper designation for Simplified Chinese (zh-Hans).

